### PR TITLE
Improve README structure and formatting

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -16,7 +16,8 @@
   "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json",
   "default": true,
   "MD033": {
-    "allowed_elements": ["div", "img", "br"]
+    "allowed_elements": ["div", "img", "br"],
   },
-  "MD041": false
+  "MD013": false,
+  "MD041": false,
 }

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Software Engineer • Systems Thinker • Knowledge Gardener
 
-*a human being, being human*
-(intending to) sleep, move, eat, grow, play, and share.
-(while I) love, laugh, cry, and eventually die.
+_a human being, being human_  
+(intending to) sleep, move, eat, grow, play, and share  
+(while I) love, laugh, cry, and eventually die
 
 COGITA·DISCE·NECTE·ENUNTIA
 
@@ -19,6 +19,22 @@ COGITA·DISCE·NECTE·ENUNTIA
 ![macOS](https://img.shields.io/badge/macOS-000000?style=flat&logo=apple&logoColor=white)
 ![Fish Shell](https://img.shields.io/badge/Fish-4AAE47?style=flat&logo=fishshell&logoColor=white)
 ![Obsidian](https://img.shields.io/badge/Obsidian-7C3AED?style=flat&logo=obsidian&logoColor=white)
+
+---
+
+Building with intention • Learning in public • Growing systems that serve humans
+
+---
+
+## 🌱 Philosophy
+
+**Yes, and…**  
+Name things once  
+Embrace simplicity  
+Ask permission once  
+Assume good intentions  
+Use one file/folder until needed  
+Accept defaults first, deviate when justified
 
 ---
 
@@ -45,17 +61,5 @@ COGITA·DISCE·NECTE·ENUNTIA
   src="http://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=philoserf&theme=github_dark"
   alt="Productive Time"
   width="49%">
-
----
-
-## 🌱 Philosophy
-
-**Yes, and…** • Name things once • Embrace simplicity
-Ask permission once • Assume good intentions
-Use one file/folder until needed • Accept defaults first, deviate when justified
-
----
-
-Building with intention • Learning in public • Growing systems that serve humans
 
 </div>


### PR DESCRIPTION
Reorganize sections for better flow: intro → tools → tagline → philosophy → stats. Break philosophy principles into readable lines for clarity and impact. Update markdownlint config for consistency.

- Move tagline before philosophy section
- Break philosophy principles into separate lines
- Update .markdownlint.jsonc formatting
